### PR TITLE
fix: address clippy warnings; update redis & tokio versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "rust-rule-engine"
-version = "1.20.0"
+version = "1.20.1"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,9 +27,9 @@ rexile = "0.5.5"
 thiserror = "2.0"
 chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
-tokio = { version = "1.50", features = ["full"], optional = true }
+tokio = { version = "1.52.3", features = ["full"], optional = true }
 nom = "8.0"
-redis = { version = "1.1", features = ["tokio-comp", "connection-manager"], optional = true }
+redis = { version = "1.2", features = ["tokio-comp", "connection-manager"], optional = true }
 
 [features]
 default = []
@@ -39,7 +39,7 @@ backward-chaining = []
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
-tokio = { version = "1.50", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 serde_yaml = "0.9"  # Used in tests/grl_harness_data.rs
 
 # Core benchmarks

--- a/benches/clone_optimization_benchmark.rs
+++ b/benches/clone_optimization_benchmark.rs
@@ -249,7 +249,8 @@ fn bench_knowledge_base_iteration(c: &mut Criterion) {
             |b, kb| {
                 b.iter(|| {
                     let mut rules = kb.get_rules(); // already clones
-                    rules.sort_by(|a, b| b.salience.cmp(&a.salience));
+                                                    // Use sort_by_key with Reverse for descending salience
+                    rules.sort_by_key(|b| std::cmp::Reverse(b.salience));
                     black_box(rules.len())
                 });
             },

--- a/src/backward/backward_engine.rs
+++ b/src/backward/backward_engine.rs
@@ -222,15 +222,13 @@ impl BackwardEngine {
         // Check actions
         for action in &rule.actions {
             match action {
-                crate::types::ActionType::Set { field, .. } => {
-                    if goal.pattern.contains(field) {
-                        return true;
-                    }
+                crate::types::ActionType::Set { field, .. } if goal.pattern.contains(field) => {
+                    return true;
                 }
-                crate::types::ActionType::MethodCall { object, method, .. } => {
-                    if goal.pattern.contains(object) || goal.pattern.contains(method) {
-                        return true;
-                    }
+                crate::types::ActionType::MethodCall { object, method, .. }
+                    if (goal.pattern.contains(object) || goal.pattern.contains(method)) =>
+                {
+                    return true;
                 }
                 _ => {}
             }

--- a/src/backward/expression.rs
+++ b/src/backward/expression.rs
@@ -196,10 +196,8 @@ impl Expression {
 
     fn extract_fields_recursive(&self, fields: &mut Vec<String>) {
         match self {
-            Expression::Field(name) => {
-                if !fields.contains(name) {
-                    fields.push(name.clone());
-                }
+            Expression::Field(name) if !fields.contains(name) => {
+                fields.push(name.clone());
             }
             Expression::Comparison { left, right, .. } => {
                 left.extract_fields_recursive(fields);

--- a/src/backward/nested.rs
+++ b/src/backward/nested.rs
@@ -273,13 +273,11 @@ impl NestedQueryParser {
                         in_parens = false;
                     }
                 }
-                'W' if in_parens && paren_depth > 0 => {
+                'W' if in_parens && paren_depth > 0 && i + 5 < chars.len() => {
                     // Check if this starts "WHERE"
-                    if i + 5 < chars.len() {
-                        let substr: String = chars[i..i + 5].iter().collect();
-                        if substr == "WHERE" {
-                            return true;
-                        }
+                    let substr: String = chars[i..i + 5].iter().collect();
+                    if substr == "WHERE" {
+                        return true;
                     }
                 }
                 _ => {}

--- a/src/backward/search.rs
+++ b/src/backward/search.rs
@@ -278,59 +278,57 @@ impl DepthFirstSearch {
             if let Some(rule) = kb.get_rule(&rule_name) {
                 // Try to execute rule (checks conditions AND executes actions)
                 match self.executor.try_execute_rule(&rule, facts) {
-                    Ok(true) => {
-                        // Rule executed successfully - derived new facts!
-                        // Now check if our goal is proven
-                        if self.check_goal_in_facts(goal, facts) {
-                            goal.status = GoalStatus::Proven;
+                    Ok(true) if self.check_goal_in_facts(goal, facts) => {
+                        // Rule executed successfully and goal is now proven
+                        goal.status = GoalStatus::Proven;
 
-                            // Save this solution
-                            self.solutions.push(Solution {
-                                path: self.path.clone(),
-                                bindings: goal.bindings.to_map(),
-                            });
+                        // Save this solution
+                        self.solutions.push(Solution {
+                            path: self.path.clone(),
+                            bindings: goal.bindings.to_map(),
+                        });
 
-                            // If we only want one solution OR we've found enough, stop searching
-                            if self.max_solutions == 1 || self.solutions.len() >= self.max_solutions
-                            {
-                                return true; // keep changes
-                            }
-
-                            // Otherwise (max_solutions > 1 and not enough yet), rollback and continue
-                            // This allows us to find alternative proof paths
-                            facts.rollback_undo_frame();
-                            self.path.pop();
-                            continue;
+                        // If we only want one solution OR we've found enough, stop searching
+                        if self.max_solutions == 1 || self.solutions.len() >= self.max_solutions {
+                            return true; // keep changes
                         }
-                        // Not proven yet: fallthrough and rollback below
+
+                        // Otherwise (max_solutions > 1 and not enough yet), rollback and continue
+                        facts.rollback_undo_frame();
+                        self.path.pop();
+                        continue;
+                    }
+                    Ok(true) => {
+                        // Rule executed but did not prove the goal yet
                     }
                     Ok(false) => {
                         // Conditions not satisfied - try to prove them recursively!
                         if self.try_prove_rule_conditions(&rule, facts, kb, depth + 1) {
                             // All conditions now satisfied! Try executing rule again
                             match self.executor.try_execute_rule(&rule, facts) {
-                                Ok(true) => {
-                                    if self.check_goal_in_facts(goal, facts) {
-                                        goal.status = GoalStatus::Proven;
+                                Ok(true) if self.check_goal_in_facts(goal, facts) => {
+                                    goal.status = GoalStatus::Proven;
 
-                                        // Save this solution
-                                        self.solutions.push(Solution {
-                                            path: self.path.clone(),
-                                            bindings: goal.bindings.to_map(),
-                                        });
+                                    // Save this solution
+                                    self.solutions.push(Solution {
+                                        path: self.path.clone(),
+                                        bindings: goal.bindings.to_map(),
+                                    });
 
-                                        // If we only want one solution OR we've found enough, stop searching
-                                        if self.max_solutions == 1
-                                            || self.solutions.len() >= self.max_solutions
-                                        {
-                                            return true; // keep changes
-                                        }
-
-                                        // Otherwise, rollback and continue searching
-                                        facts.rollback_undo_frame();
-                                        self.path.pop();
-                                        continue;
+                                    // If we only want one solution OR we've found enough, stop searching
+                                    if self.max_solutions == 1
+                                        || self.solutions.len() >= self.max_solutions
+                                    {
+                                        return true; // keep changes
                                     }
+
+                                    // Otherwise, rollback and continue searching
+                                    facts.rollback_undo_frame();
+                                    self.path.pop();
+                                    continue;
+                                }
+                                Ok(true) => {
+                                    // Executed but goal not yet proven
                                 }
                                 _ => {
                                     // execution failed on second attempt
@@ -663,15 +661,13 @@ impl DepthFirstSearch {
         // Simple heuristic: check if pattern mentions fields that this rule sets
         for action in &rule.actions {
             match action {
-                crate::types::ActionType::Set { field, .. } => {
-                    if pattern.contains(field) {
-                        return true;
-                    }
+                crate::types::ActionType::Set { field, .. } if pattern.contains(field) => {
+                    return true;
                 }
-                crate::types::ActionType::MethodCall { object, method, .. } => {
-                    if pattern.contains(object) || pattern.contains(method) {
-                        return true;
-                    }
+                crate::types::ActionType::MethodCall { object, method, .. }
+                    if (pattern.contains(object) || pattern.contains(method)) =>
+                {
+                    return true;
                 }
                 _ => {}
             }

--- a/src/engine/analytics.rs
+++ b/src/engine/analytics.rs
@@ -307,7 +307,8 @@ impl RuleAnalytics {
     /// Get the most frequently fired rules
     pub fn most_fired_rules(&self, limit: usize) -> Vec<&RuleMetrics> {
         let mut rules: Vec<&RuleMetrics> = self.rule_metrics.values().collect();
-        rules.sort_by(|a, b| b.total_fires.cmp(&a.total_fires));
+        // Use sort_by_key with Reverse for clearer intent and better performance
+        rules.sort_by_key(|b| std::cmp::Reverse(b.total_fires));
         rules.into_iter().take(limit).collect()
     }
 

--- a/src/engine/knowledge_base.rs
+++ b/src/engine/knowledge_base.rs
@@ -56,7 +56,8 @@ impl KnowledgeBase {
         rules.push(rule);
 
         // Sort rules by priority (salience)
-        rules.sort_by(|a, b| b.salience.cmp(&a.salience));
+        // Sort by salience descending using sort_by_key + Reverse
+        rules.sort_by_key(|b| std::cmp::Reverse(b.salience));
 
         // Rebuild index after sorting
         index.clear();

--- a/src/parser/grl.rs
+++ b/src/parser/grl.rs
@@ -717,23 +717,15 @@ impl GRLParser {
                     paren_count -= 1;
                     current_part.push(ch);
                 }
-                '&' if operator == "&&" && paren_count == 0 => {
-                    if chars.peek() == Some(&'&') {
-                        chars.next(); // consume second &
-                        parts.push(current_part.trim().to_string());
-                        current_part.clear();
-                    } else {
-                        current_part.push(ch);
-                    }
+                '&' if operator == "&&" && paren_count == 0 && chars.peek() == Some(&'&') => {
+                    chars.next(); // consume second &
+                    parts.push(current_part.trim().to_string());
+                    current_part.clear();
                 }
-                '|' if operator == "||" && paren_count == 0 => {
-                    if chars.peek() == Some(&'|') {
-                        chars.next(); // consume second |
-                        parts.push(current_part.trim().to_string());
-                        current_part.clear();
-                    } else {
-                        current_part.push(ch);
-                    }
+                '|' if operator == "||" && paren_count == 0 && chars.peek() == Some(&'|') => {
+                    chars.next(); // consume second |
+                    parts.push(current_part.trim().to_string());
+                    current_part.clear();
                 }
                 _ => {
                     current_part.push(ch);

--- a/src/rete/agenda.rs
+++ b/src/rete/agenda.rs
@@ -245,7 +245,8 @@ impl AdvancedAgenda {
             }
             ConflictResolutionStrategy::LEX => {
                 // Recency: most recent first
-                activations.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+                // Sort by creation time descending (most recent first) using sort_by_key
+                activations.sort_by_key(|b| std::cmp::Reverse(b.created_at));
             }
             ConflictResolutionStrategy::MEA => {
                 // Recency + Specificity: recent first, then more conditions

--- a/src/rete/alpha.rs
+++ b/src/rete/alpha.rs
@@ -177,13 +177,7 @@ impl AlphaNode {
                     "+" => left_val + right_val,
                     "-" => left_val - right_val,
                     "*" => left_val * right_val,
-                    "/" => {
-                        if right_val != 0.0 {
-                            left_val / right_val
-                        } else {
-                            return None;
-                        }
-                    }
+                    "/" if right_val != 0.0 => left_val / right_val,
                     "%" => left_val % right_val,
                     _ => return None,
                 };

--- a/src/streaming/operators.rs
+++ b/src/streaming/operators.rs
@@ -341,11 +341,9 @@ where
 
     /// Flatten back to a regular stream
     pub fn flatten(self) -> DataStream {
-        let events: Vec<StreamEvent> = self
-            .keyed_events
-            .into_iter()
-            .flat_map(|(_, events)| events)
-            .collect();
+        // Prefer iterating values directly to avoid iterating over key/value pairs
+        // Flatten the vectors of events coming from each key directly
+        let events: Vec<StreamEvent> = self.keyed_events.into_values().flatten().collect();
 
         DataStream { events }
     }


### PR DESCRIPTION
- Fix clippy issues in backward, parser, rete, streaming, engine modules
- Replace flat_map identity with flatten
- Use sort_by_key + Reverse where appropriate
- Update Cargo.toml: tokio 1.50 -> 1.52.3, redis 1.1 -> 1.2