### PR TITLE
(fix) Field reference is not evaluated in an action

### DIFF
--- a/src/parser/grl.rs
+++ b/src/parser/grl.rs
@@ -1792,7 +1792,7 @@ mod tests {
                 assert_eq!(action_type, "set");
                 assert_eq!(
                     params.get("0"),
-                    Some(&crate::types::Value::String("user.status".to_string()))
+                    Some(&crate::types::Value::Expression("user.status".to_string()))
                 );
                 assert_eq!(
                     params.get("1"),

--- a/src/parser/grl.rs
+++ b/src/parser/grl.rs
@@ -1333,7 +1333,7 @@ impl GRLParser {
 
         // Field reference (like User.Name)
         if trimmed.contains('.') {
-            return Ok(Value::String(trimmed.to_string()));
+            return Ok(Value::Expression(trimmed.to_string()));
         }
 
         // Variable reference (identifier without quotes or dots)


### PR DESCRIPTION
See discussion #86 for details.

Test rule:

    ```
    [...]
    then
        User.firstNameAgain = User.firstName;
    ```

Test facts: 

    ```
    facts.set("User.firstName", Value::String("Firsty".to_string()));
    ```

Value of `User.firstNameAgain` with v1.21.1: `Some(String("User.firstName"))`. The field name is took as a literal and not evaluated.

Expected value: `Some(String("Firsty"))`