### PR TITLE
(fix) '+' sign does not concatenate strings

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -89,8 +89,25 @@ fn find_operator(expr: &str, operators: &[char]) -> Option<usize> {
 /// Apply arithmetic operator to two values
 fn apply_operator(left: &Value, op: &str, right: &Value) -> Result<Value> {
     // Convert to numbers
-    let left_num = value_to_number(left)?;
-    let right_num = value_to_number(right)?;
+    let left_num = value_to_number(left);
+    let right_num = value_to_number(right);
+
+    // The + sign can also mean string concatenation
+    if op == "+" && (left_num.is_err() || right_num.is_err()) {
+        // at least one operand cannoy be converted to numeric
+        let concatenated = match (left, right) {
+            // both operands are strings => concatenate
+            (Value::String(s1), Value::String(s2)) => format!("{}{}", s1, s2),
+            // at least one operand is not a string => error
+            _ => return Err(RuleEngineError::EvaluationError {
+                    message: "Only strings can be concatenated".to_string()
+                })
+        };
+        return Ok(Value::String(concatenated));
+    }
+    
+    let left_num = left_num.unwrap();
+    let right_num = right_num.unwrap();
 
     let result = match op {
         "+" => left_num + right_num,

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -99,13 +99,15 @@ fn apply_operator(left: &Value, op: &str, right: &Value) -> Result<Value> {
             // both operands are strings => concatenate
             (Value::String(s1), Value::String(s2)) => format!("{}{}", s1, s2),
             // at least one operand is not a string => error
-            _ => return Err(RuleEngineError::EvaluationError {
-                    message: "Only strings can be concatenated".to_string()
+            _ => {
+                return Err(RuleEngineError::EvaluationError {
+                    message: "Only strings can be concatenated".to_string(),
                 })
+            }
         };
         return Ok(Value::String(concatenated));
     }
-    
+
     let left_num = left_num.unwrap();
     let right_num = right_num.unwrap();
 


### PR DESCRIPTION
See discussion #86 for details.

Test rule:

    ```
    [...]
    then
        User.fullNameWithoutSpace = User.firstName + User.lastName;
    ```

Test facts: 

    ```
    facts.set("User.firstName", Value::String("Firsty".to_string()));
    facts.set("User.lastName", Value::String("Lasty".to_string()));
    ```

Evaluation of this rule with v1.21.1 produces error `EvaluationError { message: "Cannot convert 'Firsty' to number" }`. The current implementation directly tries to perform an arithmetic plus whenever there is a + sign in an expression.

Expected value: `Some(String("FirstyLasty"))`