### PR TITLE
(fix) String literal is considered as a field name

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -44,9 +44,20 @@ pub fn evaluate_expression(expr: &str, facts: &Facts) -> Result<Value> {
     }
 
     // No operator found - must be a single value
-    // Could be: field reference (Order.quantity), number (100), or variable
+    // Could be: string literal, field reference (Order.quantity), number (100), or variable
 
-    // Try to parse as number first
+    // Is it a string literal?
+    if expr.len() >= 2 {
+        let unquoted = &expr[1..expr.len() - 1];
+        if (expr.starts_with('"') && expr.ends_with('"') && !unquoted.contains('"'))
+            || (expr.starts_with('\'') && expr.ends_with('\'') && !unquoted.contains('\''))
+        {
+            let unquoted = &expr[1..expr.len() - 1];
+            return Ok(Value::String(unquoted.to_string()));
+        }
+    }
+
+    // Try to parse as number
     if let Ok(int_val) = expr.parse::<i64>() {
         return Ok(Value::Integer(int_val));
     }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -110,13 +110,15 @@ fn apply_operator(left: &Value, op: &str, right: &Value) -> Result<Value> {
             // both operands are strings => concatenate
             (Value::String(s1), Value::String(s2)) => format!("{}{}", s1, s2),
             // at least one operand is not a string => error
-            _ => return Err(RuleEngineError::EvaluationError {
-                    message: "Only strings can be concatenated".to_string()
+            _ => {
+                return Err(RuleEngineError::EvaluationError {
+                    message: "Only strings can be concatenated".to_string(),
                 })
+            }
         };
         return Ok(Value::String(concatenated));
     }
-    
+
     let left_num = left_num.unwrap();
     let right_num = right_num.unwrap();
 

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -89,8 +89,25 @@ fn find_operator(expr: &str, operators: &[char]) -> Option<usize> {
 /// Apply arithmetic operator to two values
 fn apply_operator(left: &Value, op: &str, right: &Value) -> Result<Value> {
     // Convert to numbers
-    let left_num = value_to_number(left)?;
-    let right_num = value_to_number(right)?;
+    let left_num = value_to_number(left);
+    let right_num = value_to_number(right);
+
+    // The + sign can also mean string concatenation
+    if op == "+" && (left_num.is_err() || right_num.is_err()) {
+        // at least one operand cannoy be converted to numeric
+        let concatenated = match (left, right) {
+            // both operands are strings => concatenate
+            (Value::String(s1), Value::String(s2)) => format!("{}{}", s1, s2),
+            // at least one operand is not a string => error
+            _ => return Err(RuleEngineError::EvaluationError {
+                    message: "Only strings can be concatenated".to_string()
+                })
+        };
+        return Ok(Value::String(concatenated));
+    }
+    
+    let left_num = left_num.unwrap();
+    let right_num = right_num.unwrap();
 
     let result = match op {
         "+" => left_num + right_num,

--- a/src/parser/grl.rs
+++ b/src/parser/grl.rs
@@ -1296,11 +1296,13 @@ impl GRLParser {
         }
 
         // String literal
-        if (trimmed.starts_with('"') && trimmed.ends_with('"'))
-            || (trimmed.starts_with('\'') && trimmed.ends_with('\''))
-        {
+        if trimmed.len() >= 2 {
             let unquoted = &trimmed[1..trimmed.len() - 1];
-            return Ok(Value::String(unquoted.to_string()));
+            if (trimmed.starts_with('"') && trimmed.ends_with('"') && !unquoted.contains('"'))
+                || (trimmed.starts_with('\'') && trimmed.ends_with('\'') && !unquoted.contains('\''))
+            {
+                return Ok(Value::String(unquoted.to_string()));
+            }
         }
 
         // Boolean

--- a/src/parser/grl.rs
+++ b/src/parser/grl.rs
@@ -1299,7 +1299,9 @@ impl GRLParser {
         if trimmed.len() >= 2 {
             let unquoted = &trimmed[1..trimmed.len() - 1];
             if (trimmed.starts_with('"') && trimmed.ends_with('"') && !unquoted.contains('"'))
-                || (trimmed.starts_with('\'') && trimmed.ends_with('\'') && !unquoted.contains('\''))
+                || (trimmed.starts_with('\'')
+                    && trimmed.ends_with('\'')
+                    && !unquoted.contains('\''))
             {
                 return Ok(Value::String(unquoted.to_string()));
             }


### PR DESCRIPTION
See discussion #86 for details.

Test rule:

    ```
    [...]
    then
        User.fullName = User.firstName + " " + User.lastName;
    ```

Test facts: 

    ```
    facts.set("User.firstName", Value::String("Firsty".to_string()));
    facts.set("User.lastName", Value::String("Lasty".to_string()));
    ```

Evaluation of this rule with v1.21.1 produces error `EvaluationError { message: "Field '\" \"' not found in facts" }`. The string literal is searched as field name in the facts.

Expected value: `Some(String("Firsty Lasty"))`

The proposed fix relies on PR #88. It also changes a condition in `grl.rs` that is not required for this specific problem, but using the same algorithm as this fix in `expression.rs` fixes another problem when trying to evaluate e.g. `"a" + "b";`.