### PR TITLE
fix(engine): evaluate field references used in action values (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to rust-rule-engine will be documented in this file.
 
+## [1.21.4] - 2026-08-13
+
+### Fixed - 🔗 Field references in actions were not evaluated
+
+A rule like `User.firstNameAgain = User.firstName;`, or a custom action taking a field reference as an argument (e.g. `set(user.status, "approved")`), did not read the field's actual value — the field path was stored and used as a literal string instead (#86).
+
+#### Root cause and fix
+
+- `parser/grl.rs`: a bare dotted identifier (`User.firstName`) now parses to `Value::Expression` instead of `Value::String`, marking it as something that needs runtime evaluation rather than a literal.
+- `expression.rs`: `evaluate_expression`'s field lookup now tries an exact (flat) key first, then falls back to a nested path lookup (`Facts::get_nested`) — so this works whether facts are stored as flat dotted keys (`facts.set("User.firstName", ...)`) or as nested `Value::Object`s (`facts.add_value("User", Value::Object({...}))`, the shape used throughout `examples/`).
+- `engine/engine.rs`: `resolve_action_parameters` (custom action arguments) and `handle_setter_method` (`$Object.setX(value)`) now evaluate `Value::Expression` arguments against facts. If the referenced field doesn't exist yet — e.g. it's a *write* target for a `set(field, value)`-style action rather than a value to read — resolution falls back to the literal path string, preserving that existing convention.
+
+#### Compatibility
+
+- No breaking changes to the public API. Parsing output for dotted field references changes type (`Value::String` → `Value::Expression`), which only matters to code pattern-matching on that internal `Value` variant directly.
+
 ## [1.21.1] - 2026-07-12
 
 ### Fixed - 🔇 `no_loop` skip message no longer prints unconditionally

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,7 +880,7 @@ dependencies = [
 
 [[package]]
 name = "rust-rule-engine"
-version = "1.21.1"
+version = "1.21.4"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-rule-engine"
-version = "1.21.3"
+version = "1.21.4"
 edition = "2021"
 authors = ["Ton That Vu <ttvuhm@gmail.com>"]
 description = "A blazing-fast Rust rule engine with RETE algorithm, backward chaining inference, and GRL (Grule Rule Language) syntax. Features: forward/backward chaining, pattern matching, unification, O(1) rule indexing, TMS, expression evaluation, method calls, streaming with Redis state backend, watermarking, and custom functions. Production-ready for business rules, expert systems, real-time stream processing, and decision automation."

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rust Rule Engine v1.21.1 🦀⚡🚀
+# Rust Rule Engine v1.21.4 🦀⚡🚀
 
 [![Crates.io](https://img.shields.io/crates/v/rust-rule-engine.svg)](https://crates.io/crates/rust-rule-engine)
 [![Documentation](https://docs.rs/rust-rule-engine/badge.svg)](https://docs.rs/rust-rule-engine)
@@ -7,7 +7,9 @@
 
 A blazing-fast production-ready rule engine for Rust supporting **both Forward and Backward Chaining**. Features RETE-UL algorithm with **Alpha Memory Indexing** and **Beta Memory Indexing**, parallel execution, goal-driven reasoning, and GRL (Grule Rule Language) syntax.
 
-**🆕 v1.21.0**: `TimeWindow::record()` — a continuously sliding single-window counter for streaming (`streaming` feature). Answers "how many X in the trailing N seconds, right now" for rate/threshold rules, without the fixed-bucket-rejection behavior of `add_event`. Zero breaking changes.
+**🆕 v1.21.4**: Fix — field references in actions (e.g. `User.firstNameAgain = User.firstName;`, `set(user.status, "approved")`) are now evaluated to their actual value instead of being treated as a literal string. See [CHANGELOG](CHANGELOG.md#1214---2026-08-13).
+
+**v1.21.0**: `TimeWindow::record()` — a continuously sliding single-window counter for streaming (`streaming` feature). Answers "how many X in the trailing N seconds, right now" for rate/threshold rules, without the fixed-bucket-rejection behavior of `add_event`. Zero breaking changes.
 
 **v1.20.3**: Custom function calls in RETE `when` conditions — register any function via `register_function()` and call it directly in GRL rules. Enables regex matching, external lookups, and complex predicates without hardcoding patterns. Zero breaking changes.
 

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -1810,14 +1810,19 @@ impl RustRuleEngine {
     ) -> Result<String> {
         let property_name = Self::extract_property_name_from_setter(method);
 
+        let resolved_value = match new_value {
+            Value::Expression(expr) => crate::expression::evaluate_expression(expr, facts)?,
+            _ => new_value.clone(),
+        };
+
         match object_value {
             Value::Object(ref mut obj) => {
-                obj.insert(property_name.clone(), new_value.clone());
+                obj.insert(property_name.clone(), resolved_value.clone());
                 facts.add_value(object_name, object_value)?;
                 Ok(format!(
                     "Set {} to {}",
                     property_name,
-                    new_value.to_string()
+                    resolved_value.to_string()
                 ))
             }
             _ => Err(RuleEngineError::EvaluationError {
@@ -1935,11 +1940,20 @@ impl RustRuleEngine {
 
         for (key, value) in params {
             let resolved_value = match value {
+                Value::Expression(expr) => {
+                    // Field reference / arithmetic expression - evaluate against facts.
+                    // If the field doesn't exist yet (e.g. it's a write target for an
+                    // action like `set(field, value)` rather than a value to read),
+                    // fall back to the literal path string, matching the legacy
+                    // Value::String fallback behavior below.
+                    crate::expression::evaluate_expression(expr, facts)
+                        .unwrap_or_else(|_| Value::String(expr.clone()))
+                }
                 Value::String(s) => {
                     // Check if string looks like a fact reference (contains dot)
                     if s.contains('.') {
-                        // Try to get the value from facts
-                        if let Some(fact_value) = facts.get_nested(s) {
+                        // Try an exact (flat) key first, then a nested object path
+                        if let Some(fact_value) = facts.get(s).or_else(|| facts.get_nested(s)) {
                             fact_value
                         } else {
                             // If not found, keep original string

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -66,9 +66,10 @@ pub fn evaluate_expression(expr: &str, facts: &Facts) -> Result<Value> {
         return Ok(Value::Number(float_val));
     }
 
-    // Must be a field reference - get from facts
-    if let Some(value) = facts.get(expr) {
-        return Ok(value.clone());
+    // Must be a field reference - try an exact (flat) key first, then a nested
+    // object path (e.g. "User.firstName" inside a Value::Object fact named "User")
+    if let Some(value) = facts.get(expr).or_else(|| facts.get_nested(expr)) {
+        return Ok(value);
     }
 
     // Field not found - return error

--- a/src/parser/grl.rs
+++ b/src/parser/grl.rs
@@ -1335,9 +1335,9 @@ impl GRLParser {
             return Ok(Value::Expression(trimmed.to_string()));
         }
 
-        // Field reference (like User.Name)
+        // Field reference (like User.Name) - needs runtime evaluation, not a literal string
         if trimmed.contains('.') {
-            return Ok(Value::String(trimmed.to_string()));
+            return Ok(Value::Expression(trimmed.to_string()));
         }
 
         // Variable reference (identifier without quotes or dots)
@@ -1796,7 +1796,7 @@ mod tests {
                 assert_eq!(action_type, "set");
                 assert_eq!(
                     params.get("0"),
-                    Some(&crate::types::Value::String("user.status".to_string()))
+                    Some(&crate::types::Value::Expression("user.status".to_string()))
                 );
                 assert_eq!(
                     params.get("1"),


### PR DESCRIPTION
## Summary

Fixes #86 — field references used as an action's value (e.g. `User.firstNameAgain = User.firstName;`) or as a custom action argument (e.g. `set(user.status, "approved")`) were parsed as literal strings and never evaluated against facts.

This picks up where #87 left off: the parser change there (tagging dotted field references as `Value::Expression`) is the right direction, but a few consumers of that value weren't updated to handle the new variant, causing regressions. This PR includes the parser change plus the missing pieces:

- `src/parser/grl.rs`: bare dotted field reference → `Value::Expression` instead of `Value::String`.
- `src/expression.rs`: `evaluate_expression`'s field lookup now tries an exact flat-key match first, then falls back to `Facts::get_nested` — so it resolves both flat dotted-key facts (`facts.set("User.firstName", ...)`) and nested `Value::Object` facts (`facts.add_value("User", Value::Object({...}))`, the shape used throughout `examples/`). Without this, the standard nested-object case hit `Err("Field ... not found in facts")` and aborted the whole `execute()` cycle.
- `src/engine/engine.rs`:
  - `resolve_action_parameters` now evaluates `Value::Expression` custom-action arguments. On evaluation failure (field doesn't exist yet — e.g. it's a *write* target for a `set(field, value)`-style action, not a value to read) it falls back to the literal path string, preserving that existing convention used throughout the example rules.
  - `handle_setter_method` (`$Object.setX(value)`) evaluates `Value::Expression` arguments before storing them.

Also bumps to `1.21.4` and updates `CHANGELOG.md`/`README.md`.

## Test plan

- [x] `cargo test --lib` — 154 passed
- [x] `cargo test --tests` — all integration suites pass (incl. `grl_harness_data`'s data-driven cases, which exercise nested facts, custom actions, and setter-method-style actions)
- [x] `cargo test --doc` — all doctests pass
- [x] Manually verified against the exact repro from #86 (flat-key facts) — resolves correctly
- [x] Manually verified against the standard nested-`Value::Object` fact shape used in `examples/` — previously crashed with `Err`, now resolves correctly
- [x] Manually verified a custom action with a field-reference argument (`setStatus(User.firstName)`) — previously received the unresolved raw value, now receives the resolved value
- [x] Manually verified `set(field, value)`-style actions (used throughout `examples/rules/03-advanced/`) still work — field path preserved as literal when not yet a fact

🤖 Generated with [Claude Code](https://claude.com/claude-code)