### PR TITLE
Return an error instead of panicking on non-numeric operands

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -120,8 +120,8 @@ fn apply_operator(left: &Value, op: &str, right: &Value) -> Result<Value> {
         return Ok(Value::String(concatenated));
     }
 
-    let left_num = left_num.unwrap();
-    let right_num = right_num.unwrap();
+    let left_num = left_num?;
+    let right_num = right_num?;
 
     let result = match op {
         "+" => left_num + right_num,
@@ -224,6 +224,33 @@ mod tests {
         assert_eq!(
             evaluate_expression("a + b * c", &facts).unwrap(),
             Value::Integer(20)
+        );
+    }
+
+    #[test]
+    fn non_numeric_operands_return_error_not_panic() {
+        let facts = Facts::new();
+        // Applying -, *, / or % to non-numeric operands must return an error
+        // rather than panicking on value_to_number().unwrap().
+        for expr in [
+            "\"x\" - \"y\"",
+            "\"x\" * \"y\"",
+            "\"x\" / \"y\"",
+            "\"x\" % \"y\"",
+        ] {
+            assert!(
+                evaluate_expression(expr, &facts).is_err(),
+                "expected Err (not panic) for {expr}"
+            );
+        }
+        // "+" still concatenates strings and arithmetic still works.
+        assert_eq!(
+            evaluate_expression("\"foo\" + \"bar\"", &facts).unwrap(),
+            Value::String("foobar".to_string())
+        );
+        assert_eq!(
+            evaluate_expression("2 * 3", &facts).unwrap(),
+            Value::Integer(6)
         );
     }
 }


### PR DESCRIPTION
## What

`apply_operator` panics when a non-`+` arithmetic operator is applied to operands that aren't numbers.

For `+` it already handles the non-numeric case (string concatenation, or a clean `EvaluationError`). But for `-`, `*`, `/` and `%` it falls straight through to:

```rust
let left_num = left_num.unwrap();
let right_num = right_num.unwrap();
```

`value_to_number` returns `Err` for any non-numeric `Value`, so evaluating an expression whose operands are strings (or any non-numeric fact) panics and takes down the host process.

## Reproduce

```rust
let facts = Facts::new();
let _ = evaluate_expression("\"x\" - \"y\"", &facts); // panics at src/expression.rs:123
```

Same for `*`, `/`, `%`. Since `evaluate_expression` runs untrusted rule text (a rule engine evaluates GRL rules that come from outside the program), a single crafted rule expression is a denial of service.

## Fix

Propagate the existing `EvaluationError` with `?` instead of `unwrap()`. `apply_operator` already returns `Result<Value>`, so the error flows out naturally.

`"x" - "y"` and friends now return `Err(...)`; `+` string concatenation and normal arithmetic are unchanged. Adds a regression test; `cargo test --lib` (155 pass), clippy and fmt are clean.

---
*Disclosure: prepared with AI assistance; the crash was reproduced and the fix compiled/tested locally before submitting.*
